### PR TITLE
footer bug resolved

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,16 +41,16 @@ const App = () => {
               <DeveloperPortal onPathChange={setPathname} />
             </Route>
             <Route path="/testnet">
-              <Testnet />
+              <Testnet onPathChange={setPathname} />
             </Route>
             <Route path="/sdk">
-              <Sdk />
+              <Sdk onPathChange={setPathname} />
             </Route>
             <Route path="/example-client">
-              <ExampleClient />
+              <ExampleClient onPathChange={setPathname} />
             </Route>
             <Route path="/blog">
-              <Blog />
+              <Blog onPathChange={setPathname} />
             </Route>
             <Route path="/lets-connect">
               <LetsConnect onPathChange={setPathname} />

--- a/src/components/DeveloperPortal/Blog.js
+++ b/src/components/DeveloperPortal/Blog.js
@@ -1,7 +1,11 @@
-import React from "react";
+import React, { useEffect } from "react";
 import DeveloperPortalNav from "./DeveloperPortalNav";
 
-const Blog = () => {
+const Blog = (props) => {
+  useEffect(() => {
+    props.onPathChange("developer-portal");
+  }, [props]);
+
   return (
     <div className="Blog__layout Component">
       <DeveloperPortalNav blockClassName="DeveloperPortalNav__sideNav" />

--- a/src/components/DeveloperPortal/ExampleClient.js
+++ b/src/components/DeveloperPortal/ExampleClient.js
@@ -1,7 +1,11 @@
-import React from "react";
+import React, { useEffect } from "react";
 import DeveloperPortalNav from "./DeveloperPortalNav";
 
-const ExampleClient = () => {
+const ExampleClient = (props) => {
+  useEffect(() => {
+    props.onPathChange("developer-portal");
+  }, [props]);
+
   return (
     <div className="ExampleClient__layout Component">
       <DeveloperPortalNav blockClassName="DeveloperPortalNav__sideNav" />

--- a/src/components/DeveloperPortal/SDK.js
+++ b/src/components/DeveloperPortal/SDK.js
@@ -1,7 +1,11 @@
-import React from "react";
+import React, { useEffect } from "react";
 import DeveloperPortalNav from "./DeveloperPortalNav";
 
-const Sdk = () => {
+const Sdk = (props) => {
+  useEffect(() => {
+    props.onPathChange("developer-portal");
+  }, [props]);
+
   return (
     <div className="SDK__layout Component">
       <DeveloperPortalNav blockClassName="DeveloperPortalNav__sideNav" />

--- a/src/components/DeveloperPortal/Testnet.js
+++ b/src/components/DeveloperPortal/Testnet.js
@@ -1,7 +1,11 @@
-import React from "react";
+import React, { useEffect } from "react";
 import DeveloperPortalNav from "./DeveloperPortalNav";
 
-const Testnet = () => {
+const Testnet = (props) => {
+  useEffect(() => {
+    props.onPathChange("developer-portal");
+  }, [props]);
+
   return (
     <div className="Testnet__layout Component">
       <DeveloperPortalNav blockClassName="DeveloperPortalNav__sideNav" />


### PR DESCRIPTION
Problem
=======
if you load the site on a page where the footer is not meant to appear on the page, then you nav to a site where it is, the footer will not appear.
[link to Pivotal Tracker #177569963](https://www.pivotaltracker.com/story/show/177569963)

Solution
========
on path change, use useEffect to reload the animated elements.

Change summary:
---------------
* added `onPathChange` to the pages that need the path to be kept track of.

Steps to Verify:
----------------
1. try loading from different pages then naving to other pages

